### PR TITLE
Upgrade package `express-rate-limit` to version 7.5.0 and fixed some errors

### DIFF
--- a/bot/bot.js
+++ b/bot/bot.js
@@ -7,7 +7,7 @@ const CONFIG = {
     APPURL: process.env['APPURL'] || "http://172.17.0.1",
     APPURLREGEX: process.env['APPURLREGEX'] || "^.*$",
     APPFLAG: process.env['APPFLAG'] || "dev{flag}",
-    APPLIMITTIME: Number(process.env['APPLIMITTIME'] || "60"),
+    APPLIMITTIME: Number(process.env['APPLIMITTIME'] || "60000"),
     APPLIMIT: Number(process.env['APPLIMIT'] || "5"),
     APPEXTENSIONS: (() => {
         const extDir = path.join(__dirname, 'extensions');
@@ -38,8 +38,6 @@ const browserArgs = {
     })(),
     args: [
         '--disable-dev-shm-usage',
-        '--no-sandbox',
-        '--disable-setuid-sandbox',
         '--disable-gpu',
         '--no-gpu',
         '--disable-default-apps',
@@ -81,8 +79,8 @@ module.exports = {
     name: CONFIG.APPNAME,
     urlRegex: CONFIG.APPURLREGEX,
     rateLimit: {
-        windowS: CONFIG.APPLIMITTIME,
-        max: CONFIG.APPLIMIT
+        windowMs: CONFIG.APPLIMITTIME,
+        limit: CONFIG.APPLIMIT
     },
     bot: async (urlToVisit) => {
         const context = await getContext()

--- a/bot/index.js
+++ b/bot/index.js
@@ -13,7 +13,7 @@ if (process.env.USE_PROXY){
 }
 
 const limit = rateLimit({
-    ...bot,
+    ...bot.rateLimit,
     handler: ((req, res, _next) => {
         const timeRemaining = Math.ceil((req.rateLimit.resetTime - Date.now()) / 1000)
         res.status(429).json({
@@ -29,7 +29,7 @@ route.post("/", limit, async (req, res) => {
         return res.status(400).send({ error: "Url is missing." });
     }
     if (!RegExp(bot.urlRegex).test(url)) {
-        return res.status(422).send({ error: "URL din't match this regex format " + bot.urlRegex })
+        return res.status(422).send({ error: "URL didn't match this regex format " + bot.urlRegex })
     }
     if (await bot.bot(url)) {
         return res.send({ success: "Admin successfully visited the URL." });

--- a/bot/package.json
+++ b/bot/package.json
@@ -10,7 +10,7 @@
     "body-parser": "^1.20.2",
     "ejs": "^3.1.9",
     "express": "^4.18.2",
-    "express-rate-limit": "^6.7.0",
+    "express-rate-limit": "^7.5.0",
     "playwright": "^1.45.3"
   }
 }


### PR DESCRIPTION
1. Upgraded express-rate-limit to at least version 7.5.0
2. Changed property `windowS` to `windowMs` (`windowS` doesn't exist in the documentation)
3. Changed property `max` to `limit` (See [https://express-rate-limit.mintlify.app/reference/configuration#limit](https://express-rate-limit.mintlify.app/reference/configuration#limit))
4. Enabled browser sandbox
5. Fixed typo (`din't` -> `didn't`)
6. Fixed `...bot` array unpack